### PR TITLE
Include checkout agreements

### DIFF
--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -8,6 +8,11 @@
       <label data-bind="attr: {'for': getCode()}" class="label"><span data-bind="text: getTitle()"></span></label>
   </div>
   <div class="payment-method-content">
+    <div class="checkout-agreements-block">
+      <!-- ko foreach: $parent.getRegion('before-place-order') -->
+      <!-- ko template: getTemplate() --><!-- /ko -->
+      <!--/ko-->
+    </div>
     <div class="payment-method-note">
       <span data-bind="i18n: 'You will be redirected to the Satispay website.'"></span>
     </div>


### PR DESCRIPTION
If a store requires any checkout agreement (i.e. privacy and/or terms and conditions) to be flagged before the purchase, they won't show on the _Satispay_ payment method. This PR just includes the children knockout template that renders them.
To reproduce, configure one under _Store > Settings > Terms and Conditions_.